### PR TITLE
Fix supplying neo4j_uri and auth data in the cell line

### DIFF
--- a/src/cy2py/cy2.py
+++ b/src/cy2py/cy2.py
@@ -86,8 +86,8 @@ class Cy2Py(Magics):
 
             if local_ns.__contains__(var_name):
                 args[arg_key] = local_ns[var_name]
-            elif local_ns.__contains__(var_name):
-                args[arg_key] = local_ns[var_name]
+            else:
+                args[arg_key] = var_name
 
         # we try to reconstruct the query
         if not args['query'] and len(to_remove) > 0:


### PR DESCRIPTION
When using cy2py-1.1.5 it is not possible to run a cypher cell if the connection data is provided inline in the cell, like this
`%%cypher -u bolt://xxx.yy:nnnn -us USER -pw PASS`

while it does work if it is provided in python variables, like this
`neo_uri = bolt://xxx.yy:nnnn`
`neo_user = USER`
`neo_pass = PASS`
`%%cypher -u $neo_uri-us $neo_user -pw $neo_pass`

This was due to an if-statement with two identical code paths in cy2.py:__parse_args. I have pushed a fix that 'works for me' on my fork. (I can't get Docker running on my ancient dev machine so there are no tests, sorry about that.)